### PR TITLE
Upgrade couchbase-java-client to 2.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <url>https://github.com/differentway/testcontainers-java-module-couchbase</url>
 
     <properties>
-        <couchbase.client.version>2.5.4</couchbase.client.version>
+        <couchbase.client.version>2.5.7</couchbase.client.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
The couchbase-java-client change [DefaultCouchbaseEnvironment ](https://github.com/couchbase/couchbase-java-client/commit/762c2dc4460720fc5d27719630694e8badc9cd10#diff-5c321e9c5d4bec4a286000165da7bbd8)class signature. So we need to recompile testcontainers-java-module-couchbase over this new version for avoid this exception:

```
Caused by: java.lang.NoSuchMethodError: com.couchbase.client.java.env.DefaultCouchbaseEnvironment$Builder.bootstrapCarrierDirectPort(I)Lcom/couchbase/client/java/env/DefaultCouchbaseEnvironment$Builder;
	at org.testcontainers.couchbase.CouchbaseContainer.getCouchbaseEnvironment(CouchbaseContainer.java:113) ~[couchbase-testcontainer-1.11.jar:na]
	at org.testcontainers.couchbase.CouchbaseContainer.getCouchbaseCluster(CouchbaseContainer.java:124) ~[couchbase-testcontainer-1.11.jar:na]
	at org.testcontainers.couchbase.CouchbaseContainer.createBucket(CouchbaseContainer.java:250) ~[couchbase-testcontainer-1.11.jar:na]
```